### PR TITLE
Bug 2090359: Nutanix mapi-controller: misleading error message when the failure is caused by wrong credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v1.2.2
 	github.com/golang/mock v1.5.0
-	github.com/nutanix-cloud-native/prism-go-client v0.0.0-20211220162817-689f23de3cdc
+	github.com/nutanix-cloud-native/prism-go-client v0.0.0-20220511213441-cc121d3d3c27
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/openshift/api v0.0.0-20220427141643-6e7069f2fba2

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nutanix-cloud-native/prism-go-client v0.0.0-20211220162817-689f23de3cdc h1:gyjB3R/J5OM8sPjP2CJG24bPSs7bjPQW5rlH15Oft0o=
-github.com/nutanix-cloud-native/prism-go-client v0.0.0-20211220162817-689f23de3cdc/go.mod h1:2TD5wC3Ksuhp3RIj5kcC8W7T+uqGHT5yrFOAUNVknLA=
+github.com/nutanix-cloud-native/prism-go-client v0.0.0-20220511213441-cc121d3d3c27 h1:q5UWBMUuxHmDmjXo9DqP6T2Vh9E5YQBnkHnwdWU5vsk=
+github.com/nutanix-cloud-native/prism-go-client v0.0.0-20220511213441-cc121d3d3c27/go.mod h1:2TD5wC3Ksuhp3RIj5kcC8W7T+uqGHT5yrFOAUNVknLA=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/vendor/github.com/nutanix-cloud-native/prism-go-client/pkg/nutanix/client.go
+++ b/vendor/github.com/nutanix-cloud-native/prism-go-client/pkg/nutanix/client.go
@@ -253,8 +253,11 @@ func CheckResponse(r *http.Response) error {
 		return nil
 	}
 
-	pretty, _ := json.MarshalIndent(errRes, "", "  ")
-	return fmt.Errorf("error: %s", string(pretty))
+	pretty, err := json.MarshalIndent(errRes, "", "  ")
+	if err != nil {
+		return fmt.Errorf("status: %s, error-response: %+v, marshal error: %v", r.Status, errRes, err)
+	}
+	return fmt.Errorf("status: %s, error-response: %s", r.Status, string(pretty))
 }
 
 // ErrorResponse ...
@@ -270,7 +273,7 @@ type ErrorResponse struct {
 type MessageResource struct {
 
 	// Custom key-value details relevant to the status.
-	Details map[string]interface{} `json:"details,omitempty"`
+	Details interface{} `json:"details,omitempty"`
 
 	// If state is ERROR, a message describing the error.
 	Message string `json:"message"`

--- a/vendor/github.com/nutanix-cloud-native/prism-go-client/pkg/nutanix/v3/v3_structs.go
+++ b/vendor/github.com/nutanix-cloud-native/prism-go-client/pkg/nutanix/v3/v3_structs.go
@@ -294,7 +294,7 @@ type VMIntentInput struct {
 type MessageResource struct {
 
 	// Custom key-value details relevant to the status.
-	Details map[string]string `json:"details,omitempty"`
+	Details interface{} `json:"details,omitempty"`
 
 	// If state is ERROR, a message describing the error.
 	Message *string `json:"message"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -159,7 +159,7 @@ github.com/modern-go/reflect2
 # github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
 ## explicit
 github.com/monochromegane/go-gitignore
-# github.com/nutanix-cloud-native/prism-go-client v0.0.0-20211220162817-689f23de3cdc
+# github.com/nutanix-cloud-native/prism-go-client v0.0.0-20220511213441-cc121d3d3c27
 ## explicit; go 1.16
 github.com/nutanix-cloud-native/prism-go-client/pkg/nutanix
 github.com/nutanix-cloud-native/prism-go-client/pkg/nutanix/v3


### PR DESCRIPTION
Fixing Bugzilla 2090359 - Nutanix mapi-controller: misleading error message when the failure is caused by wrong credentials.

The root cause of the issue is in the prism-go-client library (https://github.com/nutanix-cloud-native/prism-go-client) error-handling code. It failed to unmarshal the prism-api call error response message to a ErrorResponse structure with the wrong type assumption.

The bug is fixed with the version ithub.com/nutanix-cloud-native/prism-go-client@v0.0.0-20220511213441-cc121d3d3c27