### PR TITLE
Bug 2090182: [Nutanix]Create a machineset with invalid image, machine stuck in "Provisioning" phase

### DIFF
--- a/pkg/actuators/machine/reconciler.go
+++ b/pkg/actuators/machine/reconciler.go
@@ -51,6 +51,13 @@ func (r *Reconciler) create() error {
 		return fmt.Errorf("failed to get user data: %w", err)
 	}
 
+	if errList := validateVMConfig(r.machineScope); len(errList) > 0 {
+		machineErr := machinecontroller.InvalidMachineConfiguration(
+			"%v: failed in validating machine providerSpec: %v",
+			r.machine.GetName(), errList.ToAggregate().Error())
+		return machineErr
+	}
+
 	vm, err := createVM(r.machineScope, userData)
 	if err != nil {
 		klog.Errorf("%s: error creating machine vm. error: %v", r.machine.Name, err)


### PR DESCRIPTION
Fixing Bug 2090182 - [Nutanix]Create a machineset with invalid image, machine stuck in "Provisioning" phase
Added validation of the VM configuration fields in the machine.spec.providerSpec before calling the prism API to create a VM. If the validation failed, an InvalidMachineConfiguration error will return with all the VM configuration errors.