### PR TITLE
Bug 2094335: [Nutanix] - debug log should not be enabled by default

### DIFF
--- a/pkg/actuators/machine/machine_scope.go
+++ b/pkg/actuators/machine/machine_scope.go
@@ -91,9 +91,10 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 
 func (s *machineScope) getNutanixClientOptions() (*clientpkg.ClientOptions, error) {
 
+	debugEnabled := klog.V(5).Enabled()
 	clientOptions := &clientpkg.ClientOptions{
 		Credentials: &nutanixClient.Credentials{},
-		Debug:       true,
+		Debug:       debugEnabled,
 	}
 
 	// Get the PC endpoint/port from the Infrastructure CR

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -52,7 +52,7 @@ func Client(options *ClientOptions) (*nutanixClientV3.Client, error) {
 		options.Credentials.URL = fmt.Sprintf("%s:%s", options.Credentials.Endpoint, options.Credentials.Port)
 	}
 
-	klog.Infof("To create nutanixClient with creds: (url: %s, insecure: %v)", options.Credentials.URL, options.Credentials.Insecure)
+	klog.Infof("To create nutanixClient with creds: (url: %s, insecure: %v, debug-log: %v)", options.Credentials.URL, options.Credentials.Insecure, options.Debug)
 	cli, err := nutanixClientV3.NewV3Client(*options.Credentials, options.Debug)
 	if err != nil {
 		klog.Errorf("Failed to create the nutanix client. error: %v", err)


### PR DESCRIPTION
Currently logs all the prism-api calls debug information in the machine-controller log, by default. The fix is to disable the prism-api debug log by default (with log-level 3), and only enable the debug log when the machine-controller's log-level is 5 or above.