### PR TITLE
OCPBUGS-18338: Fix CI by running tests natively by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ unit : CGO_ENABLED = 1
 .PHONY: all
 all: generate build images check
 
-NO_DOCKER ?= 0
+NO_DOCKER ?= 1
 
 ifeq ($(shell command -v podman > /dev/null 2>&1 ; echo $$? ), 0)
 	ENGINE=podman


### PR DESCRIPTION
Tests like lint and vet used to be ran within a container engine by default if an engine was detected, both locally and in CI.

Up until now no container engine was detected in CI, so tests would run natively there.

Now that the base image we use in CI has now started shipping `podman`, a container engine is detected by default and tests are run within podman by default. But creating nested containers doesn't work in CI at the moment and thus results in a test failure.

As such we are switching the default behaviour for tests (both locally and in CI), where now by
default no container engine is used to run tests, even if one is detected, but instead tests are run natively unless otherwise specified.