### PR TITLE
OCPBUGS-29548: IPI install fails on Nutanix when using DHCP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,5 +123,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace k8s.io/kubectl => k8s.io/kubectl v0.28.2

--- a/pkg/actuators/machine/machine_scope.go
+++ b/pkg/actuators/machine/machine_scope.go
@@ -288,26 +288,39 @@ func (s *machineScope) setProviderStatus(vm *nutanixClientV3.VMIntentResponse, c
 	s.providerStatus.VmUUID = vm.Metadata.UUID
 
 	// update machine.status.addresses
-	addresses := s.machine.Status.Addresses
-	addr := getExistingAddress(addresses, corev1.NodeInternalIP)
-	if addr != nil {
-		addr.Address = *vm.Status.Resources.NicList[0].IPEndpointList[0].IP
-	} else {
-		addresses = append(addresses, corev1.NodeAddress{
+	machineAddresses := []corev1.NodeAddress{}
+	vmIPEndpoints := make(map[string]bool)
+
+	for _, nic := range vm.Status.Resources.NicList {
+		for _, ipEndpoint := range nic.IPEndpointList {
+			if ipEndpoint.IP != nil && *ipEndpoint.IP != "" {
+				vmIPEndpoints[*ipEndpoint.IP] = true
+			}
+		}
+	}
+
+	// add the NodeInternalIP addresses to the Machine object using the vm's vmIPEndpoints
+	for ip, _ := range vmIPEndpoints {
+		// add the ip address to the Machine object.
+		machineAddresses = append(machineAddresses, corev1.NodeAddress{
 			Type:    corev1.NodeInternalIP,
-			Address: *vm.Status.Resources.NicList[0].IPEndpointList[0].IP,
+			Address: ip,
 		})
 	}
-	addr = getExistingAddress(addresses, corev1.NodeInternalDNS)
-	if addr != nil {
-		addr.Address = *vm.Spec.Name
-	} else {
-		addresses = append(addresses, corev1.NodeAddress{
-			Type:    corev1.NodeInternalDNS,
-			Address: *vm.Spec.Name,
-		})
-	}
-	s.machine.Status.Addresses = addresses
+
+	// add the NodeInternalDNS and NodeHostName addresses to the Machine object using the vm name
+	vmName := *vm.Spec.Name
+	machineAddresses = append(machineAddresses, corev1.NodeAddress{
+		Type:    corev1.NodeInternalDNS,
+		Address: vmName,
+	})
+	machineAddresses = append(machineAddresses, corev1.NodeAddress{
+		Type:    corev1.NodeHostName,
+		Address: vmName,
+	})
+
+	s.machine.Status.Addresses = machineAddresses
+	klog.V(3).Infof("%s: the machine status.addresses=%+v.", s.machine.Name, s.machine.Status.Addresses)
 
 	s.providerStatus.Conditions = setNutanixProviderConditions([]metav1.Condition{condition}, s.providerStatus.Conditions)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -797,7 +797,7 @@ k8s.io/kube-openapi/pkg/spec3
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/proto/validation
 k8s.io/kube-openapi/pkg/validation/spec
-# k8s.io/kubectl v0.28.2 => k8s.io/kubectl v0.28.2
+# k8s.io/kubectl v0.28.2
 ## explicit; go 1.20
 k8s.io/kubectl/pkg/cmd/util
 k8s.io/kubectl/pkg/drain
@@ -991,4 +991,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# k8s.io/kubectl => k8s.io/kubectl v0.28.2


### PR DESCRIPTION
OCPBUGS-29548: IPI install fails with etcdInsufficientMembers on Nutanix when using DHCP network

The back-port of the PR https://github.com/openshift/machine-api-provider-nutanix/pull/66 to branch release-4.15.