### PR TITLE
NO-JIRA: fix: CVE-2025-61726

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/machine-api-provider-nutanix
 
-go 1.24.0
+go 1.24.12 // CVE-2025-61726: DoS via net/url query parameter exhaustion; fixed in 1.24.12
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
# fix: CVE-2025-61726

## Summary

Addresses **CVE-2025-61726**, a memory exhaustion vulnerability in Go's `net/url` and `net/http` packages that can lead to denial of service when parsing URL-encoded forms with many unique query parameters.

## Vulnerability Details

| Field | Value |
|-------|--------|
| **CVE** | [CVE-2025-61726](https://nvd.nist.gov/vuln/detail/CVE-2025-61726) |
| **Component** | Go standard library (`net/url`, `net/http`) |
| **Issue** | `net/http.Request.ParseForm` does not limit the number of query parameters; parsing large forms can cause excessive memory consumption (CWE-770). |
| **Severity** | CVSS 3.1 7.5 (HIGH) — AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H |
| **Affected Go versions** | Before 1.24.12; 1.25.0 through 1.25.5 |
| **Fixed in** | Go **1.24.12** and **1.25.6** |

References:
- [Go issue #77101](https://go.dev/issue/77101)
- [Go vulnerability DB GO-2026-4341](https://pkg.go.dev/vuln/GO-2026-4341)

## Changes

### go.mod
- Bumped minimum Go version from **1.24.0** to **1.24.12** (patched release).